### PR TITLE
Refactor JSON.parse in tests

### DIFF
--- a/spec/controllers/api/v1/events_controller_spec.rb
+++ b/spec/controllers/api/v1/events_controller_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Api::V1::EventsController, type: :controller do
       end
 
       it 'returns all events' do
-        expect(JSON.parse(response.body)["events"].size).to eq(4)
+        parsed_response = JSON.parse(response.body)
+
+        expect(parsed_response["events"].size).to eq(4)
       end
 
       it 'returns status code 200' do
@@ -29,19 +31,21 @@ RSpec.describe Api::V1::EventsController, type: :controller do
       end
 
       it 'has the correct events in the correct order' do
-        expect(JSON.parse(response.body)["events"][0]["sport"]).to eq("Fencing")
-        expect(JSON.parse(response.body)["events"][0]["events"][0]).to eq("First Fencing Event")
-        expect(JSON.parse(response.body)["events"][0]["events"][1]).to eq("Second Fencing Event")
+        parsed_response = JSON.parse(response.body)
 
-        expect(JSON.parse(response.body)["events"][1]["sport"]).to eq("Golf")
-        expect(JSON.parse(response.body)["events"][1]["events"][0]).to eq("First Golf Event")
-        expect(JSON.parse(response.body)["events"][1]["events"][1]).to eq("Second Golf Event")
+        expect(parsed_response["events"][0]["sport"]).to eq("Fencing")
+        expect(parsed_response["events"][0]["events"][0]).to eq("First Fencing Event")
+        expect(parsed_response["events"][0]["events"][1]).to eq("Second Fencing Event")
 
-        expect(JSON.parse(response.body)["events"][2]["sport"]).to eq("Gymnastics")
-        expect(JSON.parse(response.body)["events"][2]["events"].count).to eq(0)
+        expect(parsed_response["events"][1]["sport"]).to eq("Golf")
+        expect(parsed_response["events"][1]["events"][0]).to eq("First Golf Event")
+        expect(parsed_response["events"][1]["events"][1]).to eq("Second Golf Event")
 
-        expect(JSON.parse(response.body)["events"][3]["sport"]).to eq("Weightlifting")
-        expect(JSON.parse(response.body)["events"][3]["events"][0]).to eq("Weightlifting Event")
+        expect(parsed_response["events"][2]["sport"]).to eq("Gymnastics")
+        expect(parsed_response["events"][2]["events"].count).to eq(0)
+
+        expect(parsed_response["events"][3]["sport"]).to eq("Weightlifting")
+        expect(parsed_response["events"][3]["events"][0]).to eq("Weightlifting Event")
       end
     end
   end
@@ -113,35 +117,38 @@ RSpec.describe Api::V1::EventsController, type: :controller do
 
       it 'returns event and all medalists' do
         get "/api/v1/events/#{@golf_event.id}/medalists"
+        parsed_response = JSON.parse(response.body)
 
-        expect(JSON.parse(response.body)["event"]).to eq("Golf Event")
-        expect(JSON.parse(response.body)["medalists"].size).to eq(3)
+        expect(parsed_response["event"]).to eq("Golf Event")
+        expect(parsed_response["medalists"].size).to eq(3)
       end
 
       it 'has the correct medalists in the correct order' do
         get "/api/v1/events/#{@golf_event.id}/medalists"
+        parsed_response = JSON.parse(response.body)
 
-        expect(JSON.parse(response.body)["medalists"][0]["name"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][0]["team"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][0]["age"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][0]["medal"]).not_to be_nil
+        expect(parsed_response["medalists"][0]["name"]).not_to be_nil
+        expect(parsed_response["medalists"][0]["team"]).not_to be_nil
+        expect(parsed_response["medalists"][0]["age"]).not_to be_nil
+        expect(parsed_response["medalists"][0]["medal"]).not_to be_nil
 
-        expect(JSON.parse(response.body)["medalists"][1]["name"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][1]["team"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][1]["age"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][1]["medal"]).not_to be_nil
+        expect(parsed_response["medalists"][1]["name"]).not_to be_nil
+        expect(parsed_response["medalists"][1]["team"]).not_to be_nil
+        expect(parsed_response["medalists"][1]["age"]).not_to be_nil
+        expect(parsed_response["medalists"][1]["medal"]).not_to be_nil
 
-        expect(JSON.parse(response.body)["medalists"][2]["name"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][2]["team"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][2]["age"]).not_to be_nil
-        expect(JSON.parse(response.body)["medalists"][2]["medal"]).not_to be_nil
+        expect(parsed_response["medalists"][2]["name"]).not_to be_nil
+        expect(parsed_response["medalists"][2]["team"]).not_to be_nil
+        expect(parsed_response["medalists"][2]["age"]).not_to be_nil
+        expect(parsed_response["medalists"][2]["medal"]).not_to be_nil
       end
 
       it 'has a response when there are no medalists' do
         get "/api/v1/events/#{@boxing_event.id}/medalists"
+        parsed_response = JSON.parse(response.body)
 
-        expect(JSON.parse(response.body)["event"]).to eq("Boxing Event")
-        expect(JSON.parse(response.body)["medalists"].size).to eq(0)
+        expect(parsed_response["event"]).to eq("Boxing Event")
+        expect(parsed_response["medalists"].size).to eq(0)
       end
     end
   end

--- a/spec/controllers/api/v1/olympian_stats_controller_spec.rb
+++ b/spec/controllers/api/v1/olympian_stats_controller_spec.rb
@@ -72,20 +72,24 @@ RSpec.describe Api::V1::OlympianStatsController, type: :controller do
     end
 
     it 'has all stats present' do
-      expect(JSON.parse(response.body)["olympian_stats"]["total_competing_olympians"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["unit"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["male_olympians"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["female_olympians"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympian_stats"]["average_age"]).not_to be_nil
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympian_stats"]["total_competing_olympians"]).not_to be_nil
+      expect(parsed_response["olympian_stats"]["average_weight"]).not_to be_nil
+      expect(parsed_response["olympian_stats"]["average_weight"]["unit"]).not_to be_nil
+      expect(parsed_response["olympian_stats"]["average_weight"]["male_olympians"]).not_to be_nil
+      expect(parsed_response["olympian_stats"]["average_weight"]["female_olympians"]).not_to be_nil
+      expect(parsed_response["olympian_stats"]["average_age"]).not_to be_nil
     end
 
     it 'has correct stats' do
-      expect(JSON.parse(response.body)["olympian_stats"]["total_competing_olympians"]).to eq(5)
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["unit"]).to eq("kg")
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["male_olympians"]).to eq(74.0)
-      expect(JSON.parse(response.body)["olympian_stats"]["average_weight"]["female_olympians"]).to eq(57.7)
-      expect(JSON.parse(response.body)["olympian_stats"]["average_age"]).to eq(21.6)
+      parsed_response = JSON.parse(response.body)
+      
+      expect(parsed_response["olympian_stats"]["total_competing_olympians"]).to eq(5)
+      expect(parsed_response["olympian_stats"]["average_weight"]["unit"]).to eq("kg")
+      expect(parsed_response["olympian_stats"]["average_weight"]["male_olympians"]).to eq(74.0)
+      expect(parsed_response["olympian_stats"]["average_weight"]["female_olympians"]).to eq(57.7)
+      expect(parsed_response["olympian_stats"]["average_age"]).to eq(21.6)
     end
   end
 end

--- a/spec/controllers/api/v1/olympians_controller_spec.rb
+++ b/spec/controllers/api/v1/olympians_controller_spec.rb
@@ -140,24 +140,28 @@ RSpec.describe Api::V1::OlympiansController, type: :controller do
       get '/api/v1/olympians'
     end
 
-    it 'returns all olympians' do
-      expect(JSON.parse(response.body)["olympians"].size).to eq(10)
-    end
-
     it 'returns status code 200' do
       expect(response).to have_http_status(:success)
     end
 
-    it 'has the correct attributes' do
-      expect(JSON.parse(response.body)["olympians"].first["name"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["team"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["age"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["sport"]).not_to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["total_medals_won"]).not_to be_nil
+    it 'returns all olympians' do
+      parsed_response = JSON.parse(response.body)
 
-      expect(JSON.parse(response.body)["olympians"].first["sex"]).to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["height"]).to be_nil
-      expect(JSON.parse(response.body)["olympians"].first["weight"]).to be_nil
+      expect(parsed_response["olympians"].size).to eq(10)
+    end
+
+    it 'has the correct attributes' do
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympians"].first["name"]).not_to be_nil
+      expect(parsed_response["olympians"].first["team"]).not_to be_nil
+      expect(parsed_response["olympians"].first["age"]).not_to be_nil
+      expect(parsed_response["olympians"].first["sport"]).not_to be_nil
+      expect(parsed_response["olympians"].first["total_medals_won"]).not_to be_nil
+
+      expect(parsed_response["olympians"].first["sex"]).to be_nil
+      expect(parsed_response["olympians"].first["height"]).to be_nil
+      expect(parsed_response["olympians"].first["weight"]).to be_nil
     end
   end
 
@@ -171,15 +175,19 @@ RSpec.describe Api::V1::OlympiansController, type: :controller do
     end
 
     it 'does not return multiple olympians' do
-      expect(JSON.parse(response.body)["olympians"].size).to eq(1)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympians"].size).to eq(1)
     end
 
     it 'returns youngest olympian' do
-      expect(JSON.parse(response.body)["olympians"].first["name"]).to eq("Dorothy Tucker")
-      expect(JSON.parse(response.body)["olympians"].first["team"]).to eq("Egypt")
-      expect(JSON.parse(response.body)["olympians"].first["age"]).to eq(18)
-      expect(JSON.parse(response.body)["olympians"].first["sport"]).to eq("Golf")
-      expect(JSON.parse(response.body)["olympians"].first["total_medals_won"]).to eq(1)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympians"].first["name"]).to eq("Dorothy Tucker")
+      expect(parsed_response["olympians"].first["team"]).to eq("Egypt")
+      expect(parsed_response["olympians"].first["age"]).to eq(18)
+      expect(parsed_response["olympians"].first["sport"]).to eq("Golf")
+      expect(parsed_response["olympians"].first["total_medals_won"]).to eq(1)
     end
   end
 
@@ -193,15 +201,19 @@ RSpec.describe Api::V1::OlympiansController, type: :controller do
     end
 
     it 'does not return multiple olympians' do
-      expect(JSON.parse(response.body)["olympians"].size).to eq(1)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympians"].size).to eq(1)
     end
 
     it 'returns youngest olympian' do
-      expect(JSON.parse(response.body)["olympians"].first["name"]).to eq("Jennifer Mcvay")
-      expect(JSON.parse(response.body)["olympians"].first["team"]).to eq("Botswana")
-      expect(JSON.parse(response.body)["olympians"].first["age"]).to eq(30)
-      expect(JSON.parse(response.body)["olympians"].first["sport"]).to eq("Fencing")
-      expect(JSON.parse(response.body)["olympians"].first["total_medals_won"]).to eq(1)
+      parsed_response = JSON.parse(response.body)
+
+      expect(parsed_response["olympians"].first["name"]).to eq("Jennifer Mcvay")
+      expect(parsed_response["olympians"].first["team"]).to eq("Botswana")
+      expect(parsed_response["olympians"].first["age"]).to eq(30)
+      expect(parsed_response["olympians"].first["sport"]).to eq("Fencing")
+      expect(parsed_response["olympians"].first["total_medals_won"]).to eq(1)
     end
   end
 end


### PR DESCRIPTION
- Assign `JSON.parse` to a variable rather calling it for every assertion

closes #36 